### PR TITLE
Update alignment to reference, and allow pre-defined atomic contributions

### DIFF
--- a/surface_analyses/structure.py
+++ b/surface_analyses/structure.py
@@ -5,11 +5,16 @@ import numpy as np
 from .data import AVERAGE_SIDECHAIN_SAA, ATOM_DATA
 from .tmalign_wrapper import MDTrajSequenceAlignment
 
-def load_aligned_trajectory(filenames, topname, stride, ref, sel):
+def load_aligned_trajectory(filenames, topname, stride, ref, protein_ref, sel):
     traj = load_trajectory(filenames, topname, stride, sel)
+    if ref and protein_ref:
+        raise ValueError("Cannot use two references")
+    if protein_ref is not None:
+        print('Aligning trajectory with TMalign')
+        traj = align_trajectory(traj, protein_ref)
     if ref is not None:
-        print('Aligning trajectory')
-        traj = align_trajectory(traj, ref)
+        ref_traj = md.load(ref)
+        traj.superpose(ref_traj, 0)
     return traj
 
 

--- a/surface_analyses/surface.py
+++ b/surface_analyses/surface.py
@@ -75,6 +75,15 @@ class Surface:
             selection = slice(None)
         return triangles_area(self.vertices[self.faces[selection]])
 
+    def vertex_areas(self):
+        """Redistribute the triangle areas to vertices"""
+        face_area = self.areas()
+        return np.bincount(
+            self.faces.ravel(),
+            weights=np.repeat(face_area, 3),
+            minlength=self.n_vertices
+        ) / 3
+
     def __repr__(self):
         return f"{self.__class__.__name__}({self.n_vertices} vertices, {self.n_faces} faces)"
 


### PR DESCRIPTION
This allows using pre-defined atomic values in commandline_hydrophobic. Also, it implements a second alignment procedure that works for non-protein molecules, and uses a reference structure with matching topology