### PR TITLE
Allow for both apbs.dx and apbs-PE0.dx as valid dx file names

### DIFF
--- a/surface_analyses/commandline_electrostatic.py
+++ b/surface_analyses/commandline_electrostatic.py
@@ -4,6 +4,7 @@ import argparse
 import csv
 from datetime import datetime
 from collections import namedtuple
+from genericpath import isfile
 import os
 import pathlib
 import pprint
@@ -318,7 +319,12 @@ def get_apbs_potential_from_mdtraj(traj, apbs_dir, pH, ion_species):
         print("apbs stderr:")
         print(apbs.stderr)
         raise RuntimeError("apbs failed")
-    dxfile = str(run_dir / "apbs.pqr-PE0.dx")
+    if (run_dir / "apbs.pqr-PE0.dx").is_file():
+        dxfile = str(run_dir / "apbs.pqr-PE0.dx")
+    elif (run_dir / "apbs.pqr.dx").is_file():
+        dxfile = str(run_dir / "apbs.pqr.dx")
+    else:
+        raise ValueError("Neither apbs.pqr-PE0.dx nor apbs.pqr.dx were found in the apbs directory.")
     griddata = load_dx(dxfile, colname='DX')
     griddata.struct = traj[0]
     return griddata

--- a/surface_analyses/commandline_electrostatic.py
+++ b/surface_analyses/commandline_electrostatic.py
@@ -4,7 +4,6 @@ import argparse
 import csv
 from datetime import datetime
 from collections import namedtuple
-from genericpath import isfile
 import os
 import pathlib
 import pprint


### PR DESCRIPTION
Add both apbs.pqr.dx and apbs-PE0.pqr.dx as valid dx file names created by APBS.
APBS v3.4.1 results in the first naming, APBS v3.0 in the second.
This PR should fix issue #22.
  