### PR TITLE
Use --whitespace for pdb2pqr

### DIFF
--- a/surface_analyses/commandline_electrostatic.py
+++ b/surface_analyses/commandline_electrostatic.py
@@ -410,7 +410,7 @@ def biggest_residue_contribution(df):
 def run_pdb2pqr(pdbfile, cwd=".", ff="AMBER", name_base="apbs", pH=None):
     if not isinstance(cwd, pathlib.Path):
         cwd = pathlib.Path(cwd)
-    command = ["pdb2pqr", f"--ff={ff}", pdbfile, name_base + ".pqr", "--apbs-input", "apbs.in"]
+    command = ["pdb2pqr", f"--ff={ff}", pdbfile, name_base + ".pqr", "--apbs-input", "apbs.in", "--whitespace"]
     if pH is not None:
         command.extend(["--titration-state-method=propka", f"--with-ph={pH}"])
     process = subprocess.run(


### PR DESCRIPTION
Hi everyone,
When running `run_electrostatic`, I have encountered couple of times problem with pqr conversion of my input pdb files.

When running the `pdb2pqr` with default settings, for some atoms this conversion made the x,y,z fields merge.
This is an example of such case: `11.992-150.282 -11.794` where x and y merged. This made apbs fail with: `Valist_readPQR: Error parsing atom 1! Please double check this atom in the pqr file, e.g., make sure there are no concatenated fields. Error reading molecules!`

In this PR I have added the `--whitespace` option for `pdb2pgr` which fixes this problem by adding whitespaces between the fields.