### PR TITLE
Fix the scaling of the hydrophobicity output, and add a unit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ pre-defined. See Eisenberg and McLachlan (1986) or Wildman and Crippen (1999)
 for references. Additionally, using `rdkit-crippen` will use a SMILES input to 
 assign Crippen parameters using the RdKit (useful for small molecules).
 
+## Output formats
+Both the electrostatics and hydrophobicity script allow writing surfaces to .ply files, using the plyfile library (https://github.com/dranjan/python-plyfile). The surfaces is colored using either the patches (where each patch gets a different color), or using the raw data (using the electrostatic potential at the vertices, or the hydrohobic potential approach of Heiden et al. https://doi.org/10.1007/BF00124359). The raw data will also be written to PLY properties, and the coordinate units are chosen to match Pymol (units of $10^-8$m).
+
+Additionally, the hydrophobicity script supports output in the numpy npz format, which is more efficient when writing many surfaces.
+
 ## Examples
 Visualize the hydrophobic potential on a non-protein molecule:
 ```

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ for references. Additionally, using `rdkit-crippen` will use a SMILES input to
 assign Crippen parameters using the RdKit (useful for small molecules).
 
 ## Output formats
-Both the electrostatics and hydrophobicity script allow writing surfaces to .ply files, using the plyfile library (https://github.com/dranjan/python-plyfile). The surfaces is colored using either the patches (where each patch gets a different color), or using the raw data (using the electrostatic potential at the vertices, or the hydrohobic potential approach of Heiden et al. https://doi.org/10.1007/BF00124359). The raw data will also be written to PLY properties, and the coordinate units are chosen to match Pymol (units of $10^-8$m).
+Both the electrostatics and hydrophobicity script allow writing surfaces to .ply files, using the [plyfile](https://github.com/dranjan/python-plyfile) library. The surfaces is colored using either the patches (where each patch gets a different color), or using the raw data (using the electrostatic potential at the vertices, or the hydrohobic potential approach of [Heiden et al.](https://doi.org/10.1007/BF00124359)). The raw data will also be written to PLY properties, and the coordinate units are chosen to match Pymol (units of 10^(-8)m).
 
 Additionally, the hydrophobicity script supports output in the numpy npz format, which is more efficient when writing many surfaces.
 

--- a/surface_analyses/commandline_hydrophobic.py
+++ b/surface_analyses/commandline_hydrophobic.py
@@ -244,7 +244,7 @@ def run_hydrophobic(
         if ply_out:
             fnames = ply_filenames(ply_out, len(surfs))
             for surf, fname in zip(surfs, fnames):
-                surf.write_ply(fname, coordinate_scaling=10)
+                surf.write_ply(fname)
         output.update(surfaces_to_dict(surfs, basename="hydrophobic_potential"))
     if out is not None:
         np.savez(out, **output)

--- a/test/commandline_hydrophobic_test.py
+++ b/test/commandline_hydrophobic_test.py
@@ -132,7 +132,7 @@ def test_surface_size():
 def test_rdkit_crippen():
     pdb = TESTS_PATH / '1csa-model1.pdb'
     args = ['--surfscore', '--smiles', CsA_SMILES]
-    with tempfile.TemporaryDirectory() as tmp:
+    with TemporaryDirectory() as tmp:
         out = Path(tmp) / "out.npz"
         run_commandline(pdb, pdb, 'rdkit-crippen', out, *args)
         with np.load(out, allow_pickle=True) as npz:

--- a/test/commandline_hydrophobic_test.py
+++ b/test/commandline_hydrophobic_test.py
@@ -99,7 +99,7 @@ def test_output_consistent(trastuzumab_run):
 def test_output_with_sc_norm():
     scale = TRASTUZUMAB_PATH / 'glmnet.csv'
     args = ['--surfscore', '--surftype', 'sc_norm']
-    parm7 = TRASTUZUMAB_PATH / 'input.parm9'
+    parm7 = TRASTUZUMAB_PATH / 'input.parm7'
     rst7 = TRASTUZUMAB_PATH / 'input.rst7'
     expected_fname = TRASTUZUMAB_PATH / 'jain-surfscore-sc-norm.npz'
     with np.load(expected_fname, allow_pickle=True) as npz:

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -17,7 +17,7 @@ def test_repr_no_error(minimal):
     repr(minimal)
 
 def test_convert_to_ply(minimal):
-    plydat = minimal.as_plydata(units_per_angstrom=1.)
+    plydat = minimal.as_plydata(units_per_nm=1.)
     assert len(plydat['vertex']) == minimal.n_vertices
     for i_dim, dim in enumerate('xyz'):
         assert np.allclose(plydat['vertex'][dim], minimal.vertices[:, i_dim])


### PR DESCRIPTION
* There is now a unit test to check that the scale of the written surface roughly matches that of the atomic coordinates. This is to avoid unit conversion errors in the future.
* Updated the README with some information on PLY output and units.